### PR TITLE
Fix do.call() 'what' must be a function or character string

### DIFF
--- a/R/Tracks-class.R
+++ b/R/Tracks-class.R
@@ -138,7 +138,7 @@ tracks <- function(..., heights, xlim, xlab = NULL, main = NULL,
         PlotList <- lapply(PlotList, function(x) {
             x + xlim(wh)
         })
-        PlotList <- do.call(PlotList, PlotList)
+        PlotList <- do.call("PlotList", PlotList)
     }
 
     ## plot background


### PR DESCRIPTION
Fix #159 